### PR TITLE
Could not install operator-sdk 1.3.0 and higher from asdf

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -46,7 +46,16 @@ get_filename() {
   local version="$1"
   local platform="$2"
 
-  echo "operator-sdk-v${version}-${platform}"
+  if [ -z "$(echo $version | egrep '[01]\.[012]\.[0-9]+')" ]; then
+    local os="$(uname | tr '[:upper:]' '[:lower:]')"
+    local arch=$(uname -m)
+    if [ "$arch" == "x86_64" ]; then
+      arch="amd64"
+    fi
+    echo "operator-sdk_${os}_${arch}"
+  else
+    echo "operator-sdk-v${version}-${platform}"
+  fi
 }
 
 get_download_url() {


### PR DESCRIPTION
Hi,

Trying to install **operator-sdk** using **asdf** seems to be successful but the command line is broken with message like : 
```
~/.asdf/installs/operator-sdk/1.4.2/bin/operator-sdk: line 1: Not : command not found
```
Examining the broken file, I noticed that it was a text file containing *Not found* message.
Then, putting an eye on https://github.com/operator-framework/operator-sdk/releases shows that Operator framework guys changed the binaries name format since version 1.3.0.

This pull request seems to fix the problem using old name format when detecting versions under 1.3.x and new name format for other stuff.

Regards.