### PR TITLE
Fix operator-sdk installation from v1.3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,5 @@ before_script:
   - git clone https://github.com/asdf-vm/asdf.git
   - . asdf/asdf.sh
 script:
+  - asdf plugin test operator-sdk $TRAVIS_BUILD_DIR --asdf-tool-version 1.2.0 --asdf-plugin-gitref $TRAVIS_COMMIT 'operator-sdk version'
   - asdf plugin test operator-sdk $TRAVIS_BUILD_DIR --asdf-plugin-gitref $TRAVIS_COMMIT 'operator-sdk version'

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ before_script:
   - git clone https://github.com/asdf-vm/asdf.git
   - . asdf/asdf.sh
 script:
-  - asdf plugin test operator-sdk $TRAVIS_BUILD_DIR 'operator-sdk version'
+  - asdf plugin test operator-sdk $TRAVIS_BUILD_DIR --asdf-plugin-gitref $TRAVIS_COMMIT 'operator-sdk version'

--- a/bin/install
+++ b/bin/install
@@ -8,17 +8,11 @@ install_operator_sdk() {
   local version=$2
   local install_path=$3
 
-  local os="$(uname | tr '[:upper:]' '[:lower:]')"
-  if [ "$os" = "darwin" ]; then
-    local os="apple-$os"
-  elif [ "$os" = "linux" ]; then
-    local os="$os-gnu"
-  fi
-  local platform="$(uname -m)-$os"
-
   local bin_install_path="$install_path/bin"
   local binary_path="$bin_install_path/operator-sdk"
-  local download_url=$(get_download_url $version $platform)
+  local filename="$(get_filename $version)"
+
+  local download_url="https://github.com/operator-framework/operator-sdk/releases/download/v${version}/${filename}"
 
   if [ "$TMPDIR" = "" ]; then
     local tmp_download_dir=$(mktemp -d -t operator-sdk_XXXXXX)
@@ -26,7 +20,7 @@ install_operator_sdk() {
     local tmp_download_dir=$TMPDIR
   fi
 
-  local download_path="$tmp_download_dir/$(get_filename $version $platform)"
+  local download_path="$tmp_download_dir/$filename"
 
   echo "Downloading operator-sdk from ${download_url} to ${download_path}"
   curl -Lo $download_path $download_url
@@ -44,16 +38,23 @@ install_operator_sdk() {
 
 get_filename() {
   local version="$1"
-  local platform="$2"
 
-  echo "operator-sdk-v${version}-${platform}"
-}
+  local os="$(uname | tr '[:upper:]' '[:lower:]')"
+  local platform="$(uname -m)"
 
-get_download_url() {
-  local version="$1"
-  local platform="$2"
-  local filename="$(get_filename $version $platform)"
-  echo "https://github.com/operator-framework/operator-sdk/releases/download/v${version}/${filename}"
+  if [ -z "$(echo $version | egrep '[01]\.[012]\.[0-9]+')" ]; then
+    if [ "$platform" == "x86_64" ]; then
+      platform="amd64"
+    fi
+    echo "operator-sdk_${os}_${platform}"
+  else
+    if [ "$os" = "darwin" ]; then
+      local os="apple-$os"
+    elif [ "$os" = "linux" ]; then
+      local os="$os-gnu"
+    fi
+    echo "operator-sdk-v${version}-${platform}-${os}"
+  fi
 }
 
 install_operator_sdk $ASDF_INSTALL_TYPE $ASDF_INSTALL_VERSION $ASDF_INSTALL_PATH


### PR DESCRIPTION
It looks like operator-sdk changed release file naming starting with version 1.3.0:
* versions < 1.3.0 filename example: **operator-sdk-v1.2.0-x86_64-apple-darwin**
* versions >= 1.3.0 filename example: **operator-sdk_darwin_amd64**

This PR fixes the same issue as https://github.com/Medium/asdf-operator-sdk/pull/3, but i removed some parts of the original PR which seemed redundant to me.